### PR TITLE
use version hash instead of service hash

### DIFF
--- a/store/index.js
+++ b/store/index.js
@@ -9,14 +9,15 @@ export const getters = {
   getService: (state) => (hash) => {
     const service = state.services.find(s => {
       return s.versions.find((version) => {
-        return version.manifestData.service.definition.hash === hash
+        console.log(version)
+        return version.versionHash === hash
       })
     })
 
     if (!service || !service.versions || service.versions.length === 0) return
 
     const manifestData = service.versions.find((version) => {
-      return version.manifestData.service.definition.hash === hash
+      return version.versionHash === hash
     }).manifestData
     if (!manifestData) return
 
@@ -24,7 +25,7 @@ export const getters = {
     if (!s || !s.definition) return
 
     const versions = service.versions.map((version) => ({
-      hash: version.manifestData.service.definition.hash
+      hash: version.versionHash
     }))
 
     const variables = {}
@@ -75,7 +76,7 @@ export const getters = {
   getServiceLatest: (state, getters) => (sid) => {
     const service = state.services.find(s => s.sid == sid)
     if (!service) return
-    const hash = service.versions[service.versions.length-1].manifestData.service.definition.hash
+    const hash = service.versions[service.versions.length - 1].versionHash
     return getters.getService(hash)
   },
 }


### PR DESCRIPTION
The marketplace was using the service hash but in the case of the marketplace the service hash is more a verification (like a checksum) and the reference for the service is the versionHash

fix https://github.com/mesg-foundation/marketplace.mesg.com/issues/15