### PR TITLE
Fix issue with invalid signature

### DIFF
--- a/api/tendermint/faucet.js
+++ b/api/tendermint/faucet.js
@@ -23,8 +23,8 @@ export default async (to, amount) => {
     fee: { amount: [{ amount: '200000', denom: 'atto' }], gas: '200000' },
     memo: '',
     chain_id: CHAIN_ID,
-    account_number: account.account_number,
-    sequence: account.sequence
+    account_number: account.account_number.toString(),
+    sequence: account.sequence.toString()
   })
   const stdTx = cosmos.sign(
     stdMsg,

--- a/pages/faucet.vue
+++ b/pages/faucet.vue
@@ -71,7 +71,7 @@
           >Get started with MESG</v-stepper-step
         >
         <v-stepper-content :step="4">
-          <template v-if="result && result.raw_log">
+          <template v-if="result && result.raw_log && result.raw_log !== '[]'">
             <v-alert type="error">{{ result.raw_log }}</v-alert>
           </template>
           <template v-else>


### PR DESCRIPTION
The account number and sequence were not in string in the message which leads to a different signature of the message.
Thanks @NicolasMahe 